### PR TITLE
Don't clone inner service

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -29,7 +29,9 @@ impl tower::Service<Cmd> for RedisService {
     }
 
     fn call(&mut self, req: Cmd) -> Self::Future {
-        let mut inner = self.inner.clone();
+        let clone = self.inner.clone();
+        // take the service that was ready
+        let mut inner = std::mem::replace(&mut self.inner, clone);
 
         Box::pin(async move { inner.req_packed_command(&req).await })
     }


### PR DESCRIPTION
As recommended by [Be careful when cloning inner services](https://docs.rs/tower-service/latest/tower_service/trait.Service.html#be-careful-when-cloning-inner-services), we call `std::mem::replace` on the cloned inner service.

(I don't fully understand why, but this is recommended)